### PR TITLE
Fix cover image fetching from Google Books

### DIFF
--- a/src/bibliographer/sources/covers.py
+++ b/src/bibliographer/sources/covers.py
@@ -83,11 +83,11 @@ def google_books_cover_retreive(catalog: CardCatalog, gbooks_volid: str) -> Opti
     Retrieve the largest image from Google Books for a volumeID.
     """
     if (
-        catalog.gbooks_volumes.contents
-        and "image_urls" in catalog.gbooks_volumes.contents
-        and catalog.gbooks_volumes.contents["image_urls"]
+        gbooks_volid in catalog.gbooks_volumes.contents
+        and "image_urls" in catalog.gbooks_volumes.contents[gbooks_volid]
+        and catalog.gbooks_volumes.contents[gbooks_volid]["image_urls"]
     ):
-        img_url = catalog.gbooks_volumes.contents["image_urls"][0]  # only 1 stored if we followed the "largest" logic
+        img_url = catalog.gbooks_volumes.contents[gbooks_volid]["image_urls"][0]  # only 1 stored if we followed the "largest" logic
         mlogger.debug(f"[COVER] Attempting GoogleBooks largest image {img_url}")
         return download_cover_from_url(img_url)
     mlogger.debug(f"[COVER] No image found for {gbooks_volid}")


### PR DESCRIPTION
The google_books_cover_retreive() function was checking for 'image_urls' at the wrong level in the data structure. It was checking the root gbooks_volumes.contents dict instead of looking up the specific volume ID first. This meant cover images were never successfully retrieved from Google Books during the populate subcommand.

Fixed by:
- Checking if gbooks_volid exists in catalog.gbooks_volumes.contents
- Looking up the specific volume's data before checking for image_urls
- Using the volume-specific image_urls list

This fix enables the populate subcommand to properly download cover images from Google Books API.