### PR TITLE
Add manual article subcommand with flexible work types

### DIFF
--- a/src/bibliographer/sources/manual.py
+++ b/src/bibliographer/sources/manual.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from bibliographer.cardcatalog import CardCatalog, CombinedCatalogBook
+from bibliographer.cardcatalog import CardCatalog, CombinedCatalogBook, CombinedWork, ManualWork
 from bibliographer.hugo import slugify
 from bibliographer.util.isbnutil import normalize_isbn
 
@@ -42,3 +42,60 @@ def manual_add(
     )
     catalog.combinedlib.contents[slug] = book
     print(f"Added manual entry {slug}")
+
+
+def manual_add_work(
+    catalog: CardCatalog,
+    work_type: str,
+    slug: str,
+    title: Optional[str] = None,
+    url: Optional[str] = None,
+    authors: Optional[list[str]] = None,
+    read_date: Optional[str] = None,
+    publish_date: Optional[str] = None,
+    isbn: Optional[str] = None,
+    purchase_date: Optional[str] = None,
+):
+    """Add a new manual work entry (article, etc.) to the manual works and combined works."""
+
+    if not title and not url:
+        raise Exception("Must specify at least --title or --url")
+
+    if isbn:
+        isbn = normalize_isbn(isbn)
+
+    # Check if slug already exists in either manual works or combined works
+    if slug in catalog.manualworks.contents:
+        raise ValueError(f"Slug {slug} already exists in manual works, edit that entry or choose a different slug")
+    if slug in catalog.combinedworks.contents:
+        raise ValueError(f"Slug {slug} already exists in combined works, edit that entry or choose a different slug")
+
+    # Create manual work entry
+    manual_work = ManualWork(
+        slug=slug,
+        work_type=work_type,
+        title=title,
+        url=url,
+        authors=authors or [],
+        read_date=read_date,
+        publish_date=publish_date,
+        isbn=isbn,
+        purchase_date=purchase_date,
+    )
+    catalog.manualworks.contents[slug] = manual_work
+
+    # Also create a combined work entry (initially identical to the manual work)
+    combined_work = CombinedWork(
+        slug=slug,
+        work_type=work_type,
+        title=title,
+        url=url,
+        authors=authors or [],
+        read_date=read_date,
+        publish_date=publish_date,
+        isbn=isbn,
+        purchase_date=purchase_date,
+    )
+    catalog.combinedworks.contents[slug] = combined_work
+
+    print(f"Added {work_type} entry: {slug}")


### PR DESCRIPTION
- Add ManualWork and CombinedWork dataclasses for generic work types (articles, books, etc.)
- Create new data files: manual_works.json and combined_works.json
- Implement manual_add_work() function for adding articles and other work types
- Add CLI subcommand 'add manualarticle' with title, URL, authors, read date, publish date
- Slug is mandatory for manually added articles
- Update CardCatalog to handle new work-agnostic data structures
- Make data paths and code paths extensible for future work types